### PR TITLE
feat: create landing page with firebase signup

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ To execute unit tests with the [Karma](https://karma-runner.github.io) test runn
 ng test
 ```
 
+## Connecting Firebase
+
+The email capture form posts sign-ups to a Firebase Realtime Database. Update
+`src/app/firebase.config.ts` with your project's database URL before running
+the landing page in production:
+
+```ts
+export const firebaseConfig = {
+  databaseUrl: 'https://your-project-id-default-rtdb.firebaseio.com'
+};
+```
+
+The service will write subscriber records to the `/subscribers` collection of
+the configured database.
+
 ## Running end-to-end tests
 
 For end-to-end (e2e) testing, run:

--- a/angular.json
+++ b/angular.json
@@ -86,5 +86,8 @@
         }
       }
     }
+  },
+  "cli": {
+    "analytics": false
   }
 }

--- a/src/app/app.config.ts
+++ b/src/app/app.config.ts
@@ -1,13 +1,5 @@
 import { ApplicationConfig, provideBrowserGlobalErrorListeners, provideZonelessChangeDetection } from '@angular/core';
-import { provideRouter } from '@angular/router';
-
-import { routes } from './app.routes';
-import { provideClientHydration, withEventReplay } from '@angular/platform-browser';
 
 export const appConfig: ApplicationConfig = {
-  providers: [
-    provideBrowserGlobalErrorListeners(),
-    provideZonelessChangeDetection(),
-    provideRouter(routes), provideClientHydration(withEventReplay())
-  ]
+  providers: [provideBrowserGlobalErrorListeners(), provideZonelessChangeDetection()]
 };

--- a/src/app/app.css
+++ b/src/app/app.css
@@ -1,15 +1,208 @@
-:root {
-  --accent: #2f7ab8;
-  --bg: #fafafa;
-  --card-bg: #fff;
-  --muted: #666;
+:host {
+  display: block;
+  min-height: 100vh;
+  background: radial-gradient(circle at top right, rgba(94, 234, 212, 0.3), transparent 55%),
+    radial-gradient(circle at bottom left, rgba(129, 140, 248, 0.35), transparent 60%),
+    #050505;
+  color: #f7f7f8;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+  padding: 3rem 1.5rem 4rem;
+  box-sizing: border-box;
 }
-* { box-sizing: border-box; }
-body, html { margin:0; font-family:system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial; background:var(--bg); }
-.app-header { display:flex; justify-content:space-between; align-items:center; padding:1rem 1.25rem; background:linear-gradient(90deg,#123,#234); color:#fff; }
-.brand { font-weight:700; }
-.nav a { color:#fff; text-decoration:none; margin-left:1rem; padding:0.25rem 0.5rem; border-radius:4px; }
-.nav a.active { background:rgba(255,255,255,0.08); text-decoration:underline; }
-.main { padding:2rem 1rem; min-height:calc(100vh - 68px); }
-.splash { max-width:820px; margin:3rem auto; text-align:center; }
-.lead { color:#444; }
+
+.page {
+  max-width: 1000px;
+  margin: 0 auto;
+}
+
+.hero {
+  text-align: center;
+  display: grid;
+  gap: 1.75rem;
+}
+
+.hero__badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0.4rem 1rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.08);
+  color: #7dd3fc;
+  font-size: 0.75rem;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+}
+
+.hero__title {
+  font-size: clamp(2.5rem, 5vw + 1rem, 4rem);
+  font-weight: 700;
+  line-height: 1.05;
+}
+
+.hero__subtitle {
+  color: rgba(247, 247, 248, 0.8);
+  font-size: 1.1rem;
+  max-width: 640px;
+  margin: 0 auto;
+  line-height: 1.6;
+}
+
+.signup {
+  display: grid;
+  gap: 0.75rem;
+  justify-items: center;
+}
+
+.signup__input {
+  display: flex;
+  gap: 0.75rem;
+  background: rgba(15, 23, 42, 0.75);
+  border: 1px solid rgba(94, 234, 212, 0.3);
+  border-radius: 999px;
+  padding: 0.35rem;
+  width: min(100%, 480px);
+  backdrop-filter: blur(12px);
+}
+
+.signup__input input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  color: inherit;
+  font-size: 1rem;
+  padding: 0.6rem 1rem;
+  outline: none;
+}
+
+.signup__input input::placeholder {
+  color: rgba(148, 163, 184, 0.8);
+}
+
+.signup__input button {
+  border: none;
+  border-radius: 999px;
+  padding: 0.6rem 1.5rem;
+  background: linear-gradient(135deg, #38bdf8, #c084fc);
+  color: #020617;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  min-width: 150px;
+}
+
+.signup__input button[disabled] {
+  opacity: 0.7;
+  cursor: progress;
+}
+
+.signup__input button:not([disabled]):hover {
+  transform: translateY(-1px);
+  box-shadow: 0 10px 25px rgba(56, 189, 248, 0.4);
+}
+
+.loading {
+  display: inline-flex;
+  gap: 0.4rem;
+  align-items: center;
+}
+
+.signup__hint {
+  font-size: 0.85rem;
+  color: rgba(148, 163, 184, 0.95);
+}
+
+.signup__hint--success {
+  color: #5ef3c5;
+}
+
+.signup__hint--error {
+  color: #f87171;
+}
+
+.hero__stats {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 1.25rem;
+  text-align: left;
+}
+
+.hero__stats h2 {
+  font-size: 2rem;
+  margin-bottom: 0.25rem;
+}
+
+.hero__stats p {
+  color: rgba(148, 163, 184, 0.9);
+  line-height: 1.5;
+}
+
+main {
+  margin-top: 4rem;
+  display: grid;
+  gap: 3rem;
+}
+
+.highlights {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 1.5rem;
+}
+
+.highlights article {
+  background: rgba(15, 23, 42, 0.75);
+  border-radius: 1rem;
+  padding: 1.5rem;
+  border: 1px solid rgba(148, 163, 184, 0.1);
+  backdrop-filter: blur(8px);
+  text-align: left;
+}
+
+.highlights h3 {
+  margin-bottom: 0.75rem;
+  font-size: 1.2rem;
+}
+
+.highlights p {
+  color: rgba(148, 163, 184, 0.9);
+  line-height: 1.6;
+}
+
+.preview {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: 1.5rem;
+}
+
+.preview__card {
+  background: linear-gradient(135deg, rgba(56, 189, 248, 0.12), rgba(192, 132, 252, 0.12));
+  border-radius: 1.25rem;
+  padding: 1.75rem;
+  border: 1px solid rgba(94, 234, 212, 0.25);
+  text-align: left;
+}
+
+.preview__card h4 {
+  margin-bottom: 0.65rem;
+  font-size: 1.1rem;
+}
+
+.preview__card p {
+  color: rgba(226, 232, 240, 0.92);
+  line-height: 1.6;
+}
+
+@media (max-width: 600px) {
+  :host {
+    padding: 2.5rem 1.25rem 3rem;
+  }
+
+  .signup__input {
+    flex-direction: column;
+    border-radius: 1.25rem;
+  }
+
+  .signup__input button {
+    width: 100%;
+  }
+}

--- a/src/app/app.html
+++ b/src/app/app.html
@@ -1,14 +1,94 @@
-<!--code is replaced with new user interface, starting twith a header and main body-->
-<header class="app-header">
-  <div class="brand">Library Archive</div>
-  <nav class="nav">
-    <!--routerLinkActiveOptions is used to configure the active link-->
-    <a routerLink="/" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }">Home</a>
-    <a routerLink="/genres" routerLinkActive="active">Genres</a>
-  </nav>
-</header>
+<div class="page">
+  <header class="hero">
+    <div class="hero__badge">New Drop</div>
+    <h1 class="hero__title">Discover the next wave of creative storytelling.</h1>
+    <p class="hero__subtitle">
+      Lumina Library curates bold, diverse voices with cinematic playlists of stories, essays,
+      and poems delivered to your inbox every week.
+    </p>
+    <form class="signup" [formGroup]="landingForm" (ngSubmit)="submit()" novalidate>
+      <div class="signup__input">
+        <input
+          type="email"
+          formControlName="email"
+          placeholder="Enter your email"
+          aria-label="Email address"
+          [attr.aria-invalid]="emailControl().invalid && emailControl().touched"
+          [disabled]="isSubmitting()"
+        />
+        <button type="submit" [disabled]="isSubmitting()">
+          <span *ngIf="!isSubmitting(); else loading">Get early access</span>
+        </button>
+        <ng-template #loading>
+          <span class="loading">Saving...</span>
+        </ng-template>
+      </div>
+      <p class="signup__hint" *ngIf="emailControl().invalid && emailControl().touched">
+        Please enter a valid email address.
+      </p>
+      <p class="signup__hint signup__hint--success" *ngIf="isSuccess()">
+        You&apos;re on the list! Watch your inbox for luminous reads.
+      </p>
+      <p class="signup__hint signup__hint--error" *ngIf="errorMessage() as message">
+        {{ message }}
+      </p>
+    </form>
+    <div class="hero__stats">
+      <div>
+        <h2>60k+</h2>
+        <p>Readers discovering new writers monthly.</p>
+      </div>
+      <div>
+        <h2>850+</h2>
+        <p>Stories, essays, and interviews in our vault.</p>
+      </div>
+      <div>
+        <h2>4.9★</h2>
+        <p>Average reader rating for the curated experience.</p>
+      </div>
+    </div>
+  </header>
 
-<main class="main">
-  <!--router-outlet is a placeholder that Angular dynamically fills based on the current router state-->
-  <router-outlet></router-outlet>
-</main>
+  <main>
+    <section class="highlights">
+      <article>
+        <h3>Editorial drops</h3>
+        <p>
+          Weekly thematic collections crafted by editors and guest curators, blending audio,
+          visuals, and written storytelling.
+        </p>
+      </article>
+      <article>
+        <h3>Community rooms</h3>
+        <p>
+          Join live salons, Q&amp;As, and micro-workshops with the creators you love and the ones you
+          haven&apos;t met yet.
+        </p>
+      </article>
+      <article>
+        <h3>Immersive playlists</h3>
+        <p>
+          Soundscapes, transcripts, and behind-the-scenes annotations to deepen every reading
+          session.
+        </p>
+      </article>
+    </section>
+
+    <section class="preview">
+      <div class="preview__card">
+        <h4>What&apos;s streaming next</h4>
+        <p>
+          “Electric Dusk” is an upcoming anthology featuring Afrofuturist poets scored by
+          experimental jazz collectives.
+        </p>
+      </div>
+      <div class="preview__card">
+        <h4>Member spotlight</h4>
+        <p>
+          Meet Sloane, a filmmaker who found their writing collaborator through Lumina&apos;s community
+          studio.
+        </p>
+      </div>
+    </section>
+  </main>
+</div>

--- a/src/app/app.spec.ts
+++ b/src/app/app.spec.ts
@@ -1,12 +1,20 @@
 import { provideZonelessChangeDetection } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 import { App } from './app';
+import { NewsletterService } from './newsletter.service';
 
 describe('App', () => {
+  let subscribeSpy: jasmine.Spy;
+
   beforeEach(async () => {
+    subscribeSpy = jasmine.createSpy('subscribe').and.resolveTo();
+
     await TestBed.configureTestingModule({
       imports: [App],
-      providers: [provideZonelessChangeDetection()]
+      providers: [
+        provideZonelessChangeDetection(),
+        { provide: NewsletterService, useValue: { subscribe: subscribeSpy } }
+      ]
     }).compileComponents();
   });
 
@@ -16,10 +24,41 @@ describe('App', () => {
     expect(app).toBeTruthy();
   });
 
-  it('should render title', () => {
+  it('should show a validation message for invalid email', async () => {
     const fixture = TestBed.createComponent(App);
     fixture.detectChanges();
-    const compiled = fixture.nativeElement as HTMLElement;
-    expect(compiled.querySelector('h1')?.textContent).toContain('Hello, first-app');
+
+    const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+    const input = fixture.nativeElement.querySelector('input[type="email"]') as HTMLInputElement;
+
+    input.value = 'invalid-email';
+    input.dispatchEvent(new Event('input'));
+    form.dispatchEvent(new Event('submit'));
+    fixture.detectChanges();
+
+    await fixture.whenStable();
+
+    const hint = fixture.nativeElement.querySelector('.signup__hint');
+    expect(hint?.textContent?.trim()).toBe('Please enter a valid email address.');
+    expect(subscribeSpy).not.toHaveBeenCalled();
+  });
+
+  it('should subscribe with a valid email', async () => {
+    const fixture = TestBed.createComponent(App);
+    fixture.detectChanges();
+
+    const form = fixture.nativeElement.querySelector('form') as HTMLFormElement;
+    const input = fixture.nativeElement.querySelector('input[type="email"]') as HTMLInputElement;
+
+    input.value = 'reader@example.com';
+    input.dispatchEvent(new Event('input'));
+    form.dispatchEvent(new Event('submit'));
+
+    await fixture.whenStable();
+
+    expect(subscribeSpy).toHaveBeenCalledWith('reader@example.com');
+    fixture.detectChanges();
+    const success = fixture.nativeElement.querySelector('.signup__hint--success');
+    expect(success?.textContent?.trim()).toContain("You're on the list!");
   });
 });

--- a/src/app/app.ts
+++ b/src/app/app.ts
@@ -1,13 +1,49 @@
-import { Component, signal } from '@angular/core';
-import { RouterOutlet, RouterLink, RouterLinkActive  } from '@angular/router'; //imported to use routing in the app
+import { Component, computed, inject, signal } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { FormBuilder, ReactiveFormsModule, Validators } from '@angular/forms';
+import { NewsletterService } from './newsletter.service';
 
-//add imports to component
 @Component({
   selector: 'app-root',
-  imports: [RouterOutlet, RouterLink, RouterLinkActive],
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
   templateUrl: './app.html',
   styleUrl: './app.css'
 })
 export class App {
-  
+  private readonly fb = inject(FormBuilder);
+  private readonly newsletter = inject(NewsletterService);
+
+  readonly isSubmitting = signal(false);
+  readonly isSuccess = signal(false);
+  readonly errorMessage = signal<string | null>(null);
+
+  readonly landingForm = this.fb.nonNullable.group({
+    email: ['', [Validators.required, Validators.email]]
+  });
+
+  readonly emailControl = computed(() => this.landingForm.controls.email);
+
+  async submit(): Promise<void> {
+    this.isSuccess.set(false);
+    this.errorMessage.set(null);
+
+    if (this.landingForm.invalid) {
+      this.landingForm.markAllAsTouched();
+      return;
+    }
+
+    this.isSubmitting.set(true);
+
+    try {
+      await this.newsletter.subscribe(this.emailControl().value);
+      this.isSuccess.set(true);
+      this.landingForm.reset({ email: '' });
+    } catch (error) {
+      console.error('Failed to save subscription', error);
+      this.errorMessage.set('We could not save your email. Please try again.');
+    } finally {
+      this.isSubmitting.set(false);
+    }
+  }
 }

--- a/src/app/firebase.config.ts
+++ b/src/app/firebase.config.ts
@@ -1,0 +1,11 @@
+export interface FirebaseConfig {
+  databaseUrl: string;
+}
+
+export const firebaseConfig: FirebaseConfig = {
+  /**
+   * Replace the URL below with your Firebase Realtime Database URL, e.g.
+   * https://your-project-id-default-rtdb.firebaseio.com
+   */
+  databaseUrl: 'https://your-project-id-default-rtdb.firebaseio.com'
+};

--- a/src/app/newsletter.service.ts
+++ b/src/app/newsletter.service.ts
@@ -1,0 +1,24 @@
+import { Injectable } from '@angular/core';
+import { firebaseConfig } from './firebase.config';
+
+@Injectable({ providedIn: 'root' })
+export class NewsletterService {
+  private readonly endpoint = `${firebaseConfig.databaseUrl.replace(/\/$/, '')}/subscribers.json`;
+
+  async subscribe(email: string): Promise<void> {
+    const response = await fetch(this.endpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json'
+      },
+      body: JSON.stringify({
+        email,
+        subscribedAt: new Date().toISOString()
+      })
+    });
+
+    if (!response.ok) {
+      throw new Error('Unable to save subscription');
+    }
+  }
+}

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,16 @@
-/* You can add global styles to this file, and also import other style files */
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap');
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background-color: #050505;
+  color: #f7f7f8;
+  font-family: 'Inter', 'Segoe UI', sans-serif;
+}
+
+a {
+  color: inherit;
+}


### PR DESCRIPTION
## Summary
- redesign the shell into a single-page Lumina Library landing experience with hero content, highlights, and responsive styling
- add a Firebase-configurable newsletter service that persists signups to the Realtime Database via REST
- document the Firebase setup and disable Angular CLI analytics to avoid interactive prompts during testing

## Testing
- ⚠️ `npm test -- --watch=false --browsers=ChromeHeadless` *(fails: ChromeHeadless binary not available in container)*

------
https://chatgpt.com/codex/tasks/task_b_68deade683f883319412b9169b81f7d8